### PR TITLE
Bugfix: badge.title displays badge.description

### DIFF
--- a/javascripts/discourse/initializers/initialize-discourse-post-badges.js.es6
+++ b/javascripts/discourse/initializers/initialize-discourse-post-badges.js.es6
@@ -106,7 +106,7 @@ export default {
       const isMobileView = Discourse.Site.currentProp("mobileView");
       const location = isMobileView ? "before" : "after";
       const displayedBadges = settings.badges
-        .split(",")
+        .split("|")
         .filter(Boolean)
         .map(badge => badge.toLowerCase());
 

--- a/javascripts/discourse/initializers/initialize-discourse-post-badges.js.es6
+++ b/javascripts/discourse/initializers/initialize-discourse-post-badges.js.es6
@@ -65,10 +65,11 @@ function loadUserBadges(username, displayedBadges) {
           icon: badge.icon.replace("fa-", ""),
           image: badge.image,
           className: BADGE_CLASS[badge.badge_type_id - 1],
-          name: badge.slug,
+          name: badge.name,
           id: badge.id,
           badgeGroup: badge.badge_grouping_id,
-          title: badge.description,
+          title: badge.name,
+          description: badge.description
           url: `/badges/${badge.id}/${badge.slug}${badgePage}`
         };
       });

--- a/javascripts/discourse/initializers/initialize-discourse-post-badges.js.es6
+++ b/javascripts/discourse/initializers/initialize-discourse-post-badges.js.es6
@@ -114,6 +114,8 @@ export default {
         .split("|")
         .filter(Boolean)
         .map(badge => badge.toLowerCase());
+      // BUG: badge.name renders badge.slug
+      console.log("displayedBadges:", displayedBadges);
 
       api.decorateWidget(`poster-name:${location}`, decorator => {
         const username = decorator.attrs.username;

--- a/javascripts/discourse/initializers/initialize-discourse-post-badges.js.es6
+++ b/javascripts/discourse/initializers/initialize-discourse-post-badges.js.es6
@@ -21,9 +21,6 @@ const USER_BADGE_PAGE = "user's badge page";
 
 function buildBadge(badge) {
   let iconBody;
-  
-  // BUG: badge.name renders badge.slug
-  console.log("badge:", badge);
 
   if (badge.image) {
     const img = document.createElement("img");
@@ -109,14 +106,10 @@ export default {
     withPluginApi("0.8.25", api => {
       const isMobileView = Discourse.Site.currentProp("mobileView");
       const location = isMobileView ? "before" : "after";
-      // BUG: badge.name renders badge.slug
-      console.log("settings.badges:", settings.badges);
       const displayedBadges = settings.badges
         .split("|")
         .filter(Boolean)
         .map(badge => badge.toLowerCase());
-      // BUG: badge.name renders badge.slug
-      console.log("displayedBadges:", displayedBadges);
 
       api.decorateWidget(`poster-name:${location}`, decorator => {
         const username = decorator.attrs.username;

--- a/javascripts/discourse/initializers/initialize-discourse-post-badges.js.es6
+++ b/javascripts/discourse/initializers/initialize-discourse-post-badges.js.es6
@@ -108,6 +108,8 @@ export default {
     withPluginApi("0.8.25", api => {
       const isMobileView = Discourse.Site.currentProp("mobileView");
       const location = isMobileView ? "before" : "after";
+      // BUG: badge.name renders badge.slug
+      console.log("settings.badges:", settings.badges);
       const displayedBadges = settings.badges
         .split("|")
         .filter(Boolean)

--- a/javascripts/discourse/initializers/initialize-discourse-post-badges.js.es6
+++ b/javascripts/discourse/initializers/initialize-discourse-post-badges.js.es6
@@ -41,7 +41,7 @@ function buildBadge(badge) {
   span.classList.add("poster-icon");
   span.classList.add(badge.className);
   span.classList.add(TRUST_LEVEL_BADGE[badge.id - 1]);
-  span.setAttribute("title", badge.title);
+  span.setAttribute("title", badge.name);
   span.appendChild(iconBody);
   return span;
 }

--- a/javascripts/discourse/initializers/initialize-discourse-post-badges.js.es6
+++ b/javascripts/discourse/initializers/initialize-discourse-post-badges.js.es6
@@ -69,7 +69,7 @@ function loadUserBadges(username, displayedBadges) {
           id: badge.id,
           badgeGroup: badge.badge_grouping_id,
           title: badge.name,
-          description: badge.description
+          description: badge.description,
           url: `/badges/${badge.id}/${badge.slug}${badgePage}`
         };
       });

--- a/javascripts/discourse/initializers/initialize-discourse-post-badges.js.es6
+++ b/javascripts/discourse/initializers/initialize-discourse-post-badges.js.es6
@@ -44,7 +44,7 @@ function buildBadge(badge) {
   span.classList.add("poster-icon");
   span.classList.add(badge.className);
   span.classList.add(TRUST_LEVEL_BADGE[badge.id - 1]);
-  span.setAttribute("title", badge.name);
+  span.setAttribute("title", badge.title);
   span.appendChild(iconBody);
   return span;
 }

--- a/javascripts/discourse/initializers/initialize-discourse-post-badges.js.es6
+++ b/javascripts/discourse/initializers/initialize-discourse-post-badges.js.es6
@@ -21,6 +21,9 @@ const USER_BADGE_PAGE = "user's badge page";
 
 function buildBadge(badge) {
   let iconBody;
+  
+  // BUG: badge.name renders badge.slug
+  console.log("badge:", badge);
 
   if (badge.image) {
     const img = document.createElement("img");

--- a/javascripts/discourse/initializers/initialize-discourse-post-badges.js.es6
+++ b/javascripts/discourse/initializers/initialize-discourse-post-badges.js.es6
@@ -106,7 +106,7 @@ export default {
       const isMobileView = Discourse.Site.currentProp("mobileView");
       const location = isMobileView ? "before" : "after";
       const displayedBadges = settings.badges
-        .split("|")
+        .split(",")
         .filter(Boolean)
         .map(badge => badge.toLowerCase());
 


### PR DESCRIPTION
Currently, this theme component renders the badge description in the tooltip:
![2020-10-06_11-16-00](https://user-images.githubusercontent.com/16314437/95811568-2f8ae380-0cd9-11eb-8cef-1e4555f86d66.gif)

---
This PR renders the badge name in the tooltip instead:
![post-badge-title-fix](https://user-images.githubusercontent.com/16314437/95811979-061e8780-0cda-11eb-8a8a-85c7b3deafbc.gif)

