### PR TITLE
FIX: blank page appears when posts is filtered in a topic

### DIFF
--- a/javascripts/discourse/initializers/initialize-discourse-post-badges.js
+++ b/javascripts/discourse/initializers/initialize-discourse-post-badges.js
@@ -104,7 +104,7 @@ export default {
 
       api.decorateWidget(`poster-name:${location}`, (decorator) => {
         const post = decorator.widget.findAncestorModel();
-        if (post.userBadges) {
+        if (post?.userBadges) {
           const preparedBadges = prepareBadges(
             post.userBadges,
             displayedBadges,

--- a/spec/system/post_badges_spec.rb
+++ b/spec/system/post_badges_spec.rb
@@ -3,6 +3,7 @@
 RSpec.describe "Post Badges theme component", system: true do
   let!(:theme) { upload_theme_component }
   let(:user) { Fabricate(:user) }
+  let(:user2) { Fabricate(:user) }
   let(:post) { Fabricate(:post, user: user) }
 
   let!(:user_badge) { Fabricate(:user_badge, badge: Badge.find_by(name: "First Like"), user: user) }
@@ -14,7 +15,27 @@ RSpec.describe "Post Badges theme component", system: true do
     visit "/t/#{post.topic_id}"
 
     expect(page).to have_selector("#post_1")
-    badge = find(".poster-icon-container .badge-type-bronze")
+    badge = find("#post_1 .poster-icon-container .badge-type-bronze")
+    expect(badge).to have_link(
+      href: "/badges/#{user_badge.badge_id}/#{user_badge.badge.slug}?username=#{user.username}",
+    )
+  end
+
+  it "should display user badges on filtered posts" do
+    Fabricate(:post, topic: topic, user: user2)
+    Fabricate(:post, topic: topic, user: user)
+
+    theme.update_setting(:badges, "first like")
+    theme.save!
+
+    visit "/t/#{post.topic_id}"
+
+    expect(page).to have_selector("#post_3")
+    find("#post_3 .post-avatar").click
+    expect(page).to have_selector("#user-card")
+    find(".usercard-controls li button:has(svg.d-icon-filter)").click
+
+    badge = find("#post_3 .poster-icon-container .badge-type-bronze")
     expect(badge).to have_link(
       href: "/badges/#{user_badge.badge_id}/#{user_badge.badge.slug}?username=#{user.username}",
     )

--- a/spec/system/post_badges_spec.rb
+++ b/spec/system/post_badges_spec.rb
@@ -2,9 +2,11 @@
 
 RSpec.describe "Post Badges theme component", system: true do
   let!(:theme) { upload_theme_component }
+  let(:category) { Fabricate(:category) }
+  let(:topic) { Fabricate(:topic, category: category) }
   let(:user) { Fabricate(:user) }
   let(:user2) { Fabricate(:user) }
-  let(:post) { Fabricate(:post, user: user) }
+  let(:post) { Fabricate(:post, topic: topic, user: user) }
 
   let!(:user_badge) { Fabricate(:user_badge, badge: Badge.find_by(name: "First Like"), user: user) }
 
@@ -22,8 +24,8 @@ RSpec.describe "Post Badges theme component", system: true do
   end
 
   it "should display user badges on filtered posts" do
-    Fabricate(:post, user: user2)
-    Fabricate(:post, user: user)
+    Fabricate(:post, topic: topic, user: user2)
+    Fabricate(:post, topic: topic, user: user)
 
     theme.update_setting(:badges, "first like")
     theme.save!

--- a/spec/system/post_badges_spec.rb
+++ b/spec/system/post_badges_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe "Post Badges theme component", system: true do
   end
 
   it "should display user badges on filtered posts" do
-    Fabricate(:post, topic: topic, user: user2)
-    Fabricate(:post, topic: topic, user: user)
+    Fabricate(:post, user: user2)
+    Fabricate(:post, user: user)
 
     theme.update_setting(:badges, "first like")
     theme.save!


### PR DESCRIPTION
meta: https://meta.discourse.org/t/posts-in-topic-filter-not-working/365968

When you filter your messages in a topic, it results in a blank page, and with the following error in the console:

![image](https://github.com/user-attachments/assets/fa1bca45-bf2d-4d00-bd37-2a954fa421f4)

This PR ensures `post` model exists before checking for user badges.