### PR TITLE
FIX: Correctly handle post with no badge info

### DIFF
--- a/javascripts/discourse/initializers/initialize-discourse-post-badges.gjs
+++ b/javascripts/discourse/initializers/initialize-discourse-post-badges.gjs
@@ -121,7 +121,7 @@ export default {
         ({ value: classes, context }) => {
           let trustLevel = "";
           let highestBadge = 0;
-          context.post.userBadges.forEach((badge) => {
+          context.post.userBadges?.forEach((badge) => {
             if (badge.badge_grouping_id === 4 && badge.id > highestBadge) {
               highestBadge = badge.id;
               trustLevel = `${TRUST_LEVEL_BADGE[highestBadge - 1]}-highest`;


### PR DESCRIPTION
Followup to 010b9c49269a736b6ac5f4ce1ffbaf596de6d1cb